### PR TITLE
Update gulp-git-push dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Tiago Ferreira",
   "license": "ISC",
   "dependencies": {
-    "gulp-git": "^1.7.1",
+    "gulp-git": "^2.5.1",
     "gulp-util": "^3.0.7",
     "map-stream": "^0.1.0",
     "object-assign": "^4.0.1"
@@ -22,7 +22,7 @@
     "gulp": "^3.9.1",
     "gulp-bump": "^2.1.0",
     "gulp-filter": "^4.0.0",
-    "gulp-git": "^1.7.1",
+    "gulp-git": "^2.5.1",
     "gulp-tag-version": "^1.3.0",
     "yargs": "^4.7.0"
   }


### PR DESCRIPTION
Hi, my name is Carlos Curotto, i work for Blue Alba. I started this pull request to propose you to upgrade the gulp-git version to (2.5.1) since the current one (1.7.1) depends on require-dir (0.1.0) which is not compatible with Node 8. We are migrating to Node 8 so we need to update to require-dir (0.3.2).

If you agree, please, go ahead and let us know so we can update to the new gulp-git-push version.

Thanks a lot,
Carlos.